### PR TITLE
Ps 250

### DIFF
--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -121,7 +121,14 @@ defmodule Elasticsearch.Index.Bulk do
   end
 
   defp put_bulk_page(config, index_name, items) when is_list(items) do
-    Elasticsearch.put(config, "/#{index_name}/_doc/_bulk", Enum.join(items))
+    IO.inspect(config)
+    case Elasticsearch.put(config, "/#{index_name}/_doc/_bulk", Enum.join(items)) do
+      {:ok, response} -> {:ok, response}
+      {:error, elasticsearch_exception} ->
+        Logger.error("bulk_page_index error: #{inspect(elasticsearch_exception, limit: :infinity)}")
+        Logger.info("bulk_page_index errored items: #{inspect(items, limit: :infinity)}")
+        {:error, elasticsearch_exception}
+    end
   end
 
   defp collect_errors({:ok, %{"errors" => true} = response}, errors, action) do

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -128,7 +128,8 @@ defmodule Elasticsearch.Index.Bulk do
       {:error, elasticsearch_exception} ->
         if Map.get(config, :enable_debug_bulk_put) do
           Logger.error("put_bulk_page error: #{inspect(elasticsearch_exception, limit: :infinity)}")
-          Logger.info("put_bulk_page errored items: #{inspect(items, limit: :infinity)}")
+          Enum.each(items, & Logger.info("put_bulk_page errored item: #{inspect(&1, limit: :infinity)}"))
+          Logger.info("---- put_bulk_page end error items ----")
         end
 
         {:error, elasticsearch_exception}

--- a/lib/elasticsearch/indexing/bulk.ex
+++ b/lib/elasticsearch/indexing/bulk.ex
@@ -121,12 +121,16 @@ defmodule Elasticsearch.Index.Bulk do
   end
 
   defp put_bulk_page(config, index_name, items) when is_list(items) do
-    IO.inspect(config)
     case Elasticsearch.put(config, "/#{index_name}/_doc/_bulk", Enum.join(items)) do
-      {:ok, response} -> {:ok, response}
+      {:ok, response} ->
+        {:ok, response}
+
       {:error, elasticsearch_exception} ->
-        Logger.error("bulk_page_index error: #{inspect(elasticsearch_exception, limit: :infinity)}")
-        Logger.info("bulk_page_index errored items: #{inspect(items, limit: :infinity)}")
+        if Map.get(config, :enable_debug_bulk_put) do
+          Logger.error("put_bulk_page error: #{inspect(elasticsearch_exception, limit: :infinity)}")
+          Logger.info("put_bulk_page errored items: #{inspect(items, limit: :infinity)}")
+        end
+
         {:error, elasticsearch_exception}
     end
   end


### PR DESCRIPTION
Add some details to the failure in staging.

QA:

Update your search service to use this PR in place of the current elasticsearch:
```
{:elasticsearch, git: "git@github.com:hyphenPaul/elasticsearch-elixir.git", ref: "8f7a93f370a0f27fd3fbe6652392f144d3e1147a"}
```

Update your config to something like this:
```
# Config for Elasticsearch
config :product_search_service, ProductSearchService.Elasticsearch.Cluster,
  url: "http://elasticsearch:9200",

  # If your Elasticsearch cluster uses HTTP basic authentication,
  # specify the username and password here:
  # username: "username",
  # password: "password",

  # If you want to mock the responses of the Elasticsearch JSON API
  # for testing or other purposes, you can inject a different module
  # here. It must implement the Elasticsearch.API behaviour.
  api: Elasticsearch.API.HTTP,

  # Customize the library used for JSON encoding/decoding.
  json_library: Jason,

  # Enable debug output for bulk put failures
  enable_debug_bulk_put: true,

  # You should configure each index which you maintain in Elasticsearch here.
  # This configuration will be read by the `mix elasticsearch.build` task,
  # described below.
  indexes: %{
    # This is the base name of the Elasticsearch index. Each index will be
    # built with a timestamp included in the name, like "posts-5902341238".
    # It will then be aliased to "posts" for easy querying.
    products: %{
      # This file describes the mappings and settings for your index. It will
      # be posted as-is to Elasticsearch when you create your index, and
      # therefore allows all the settings you could post directly.
      settings: "priv/product.json",

      # This store module must implement a store behaviour. It will be used to
      # fetch data for each source in each indexes' `sources` list, below:
      store: ProductSearchService.Elasticsearch.Store,

      # This is the list of data sources that should be used to populate this
      # index. The `:store` module above will be passed each one of these
      # sources for fetching.
      #
      # Each piece of data that is returned by the store must implement the
      # Elasticsearch.Document protocol.
      sources: [ProductSearchService.Elasticsearch.Document],

      # When indexing data using the `mix elasticsearch.build` task,
      # control the data ingestion rate by raising or lowering the number
      # of items to send in each bulk request.
      bulk_page_size: 2000,

      # Likewise, wait a given period between posting pages to give
      # Elasticsearch time to catch up.
      # 5 seconds
      bulk_wait_interval: 5_000
    }
  },
  # HTTPoison Options
  default_options: [
    timeout: 60_000,
    recv_timeout: 60_000,
    hackney: [pool: :elasticsearch_pool]
  ]
```

Restart and run this in a console:
```
ProductSearchService.Elasticsearch.reindex_all()
```

At the end of the reindex, you should see more details:
```
19:31:21.156 [error] put_bulk_page error: %HTTPoison.Error{id: nil, reason: :nxdomain}
19:31:21.553 [info]  put_bulk_page errored items: <<PAYLOAD OF LAST PAGE>>
```

